### PR TITLE
Add login and main interface

### DIFF
--- a/HelloAIApp/ContentView.swift
+++ b/HelloAIApp/ContentView.swift
@@ -1,10 +1,13 @@
 import SwiftUI
 
 struct ContentView: View {
+    @State private var isLoggedIn = false
+
     var body: some View {
-        VStack {
-            Text("Hello, AI!")
-                .padding()
+        if isLoggedIn {
+            MainView()
+        } else {
+            LoginView(isLoggedIn: $isLoggedIn)
         }
     }
 }
@@ -14,3 +17,4 @@ struct ContentView_Previews: PreviewProvider {
         ContentView()
     }
 }
+

--- a/HelloAIApp/LoginView.swift
+++ b/HelloAIApp/LoginView.swift
@@ -1,0 +1,41 @@
+import SwiftUI
+
+struct LoginView: View {
+    @Binding var isLoggedIn: Bool
+    @State private var username: String = ""
+    @State private var password: String = ""
+
+    var body: some View {
+        VStack(spacing: 20) {
+            Text("Welcome to AlwaysAI")
+                .font(.largeTitle)
+                .padding(.top, 40)
+
+            TextField("Username", text: $username)
+                .textFieldStyle(RoundedBorderTextFieldStyle())
+                .padding(.horizontal, 40)
+
+            SecureField("Password", text: $password)
+                .textFieldStyle(RoundedBorderTextFieldStyle())
+                .padding(.horizontal, 40)
+
+            Button(action: { isLoggedIn = true }) {
+                Text("Log In")
+                    .frame(maxWidth: .infinity)
+                    .padding()
+                    .background(Color.blue)
+                    .foregroundColor(.white)
+                    .cornerRadius(8)
+                    .padding(.horizontal, 40)
+            }
+            Spacer()
+        }
+    }
+}
+
+struct LoginView_Previews: PreviewProvider {
+    static var previews: some View {
+        LoginView(isLoggedIn: .constant(false))
+    }
+}
+

--- a/HelloAIApp/MainView.swift
+++ b/HelloAIApp/MainView.swift
@@ -1,0 +1,50 @@
+import SwiftUI
+
+struct MainView: View {
+    @State private var currentTaskIndex: Int = 0
+    private let tasks = [
+        "Meet the team at 2pm",
+        "Review project proposal",
+        "Plan weekend trip",
+        "Prepare dinner ingredients"
+    ]
+
+    var body: some View {
+        VStack {
+            Spacer()
+            Text(tasks[currentTaskIndex])
+                .font(.title2)
+                .multilineTextAlignment(.center)
+                .padding()
+            Spacer()
+            HStack {
+                Button(action: { nextTask() }) {
+                    Image(systemName: "xmark.circle.fill")
+                        .resizable()
+                        .frame(width: 60, height: 60)
+                        .foregroundColor(.red)
+                }
+                Spacer()
+                Button(action: { nextTask() }) {
+                    Image(systemName: "checkmark.circle.fill")
+                        .resizable()
+                        .frame(width: 60, height: 60)
+                        .foregroundColor(.green)
+                }
+            }
+            .padding(.horizontal, 60)
+            .padding(.bottom, 40)
+        }
+    }
+
+    private func nextTask() {
+        currentTaskIndex = (currentTaskIndex + 1) % tasks.count
+    }
+}
+
+struct MainView_Previews: PreviewProvider {
+    static var previews: some View {
+        MainView()
+    }
+}
+

--- a/HelloAIApp/README.md
+++ b/HelloAIApp/README.md
@@ -1,9 +1,12 @@
 # HelloAIApp
 
-This is a minimal SwiftUI example project. To use it:
+This sample SwiftUI project now demonstrates a simple login screen and a main interface similar to a dating app.
+
+## Running the app
 
 1. Open Xcode and choose **File > Open**.
 2. Navigate to this folder and select the project.
 3. Build and run on the simulator or a connected iOS device.
 
-The main entry point is `HelloAIApp.swift`, which displays a `ContentView` containing a text greeting.
+After launching, you'll see a login form. Once logged in, the main screen presents a feed of task messages with green **Accept** and red **Reject** buttons at the bottom.
+


### PR DESCRIPTION
## Summary
- add login screen with username and password fields
- show main screen after login with accept/reject buttons like a dating app
- update project README

## Testing
- `swift --version`
- `swift build` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_684b7106a7248333bd461e7411fbfe5b